### PR TITLE
Fix build on Arch Linux with gcc 15.2.1 and QT 6.10.0

### DIFF
--- a/src/ClassLogic.cpp
+++ b/src/ClassLogic.cpp
@@ -15,7 +15,7 @@
 static QVector<net_t> visitedNets; // Avoid loops by keeping nets that are already visited
 static QVector<tran_t> visitedTrans; // Avoid path duplication by keeping transistors that are already visited
 
-Logic::Logic(net_t n, LogicOp op, bool checkVisitedNets, bool first) : outnet(n), op(op)
+Logic::Logic(net_t n, LogicOp op, bool checkVisitedNets, bool first) : op(op), outnet(n)
 {
     QSettings settings;
     QString termNodes = settings.value("schematicTermNodes").toString();

--- a/src/ClassVisual.cpp
+++ b/src/ClassVisual.cpp
@@ -802,7 +802,7 @@ void ClassVisual::drawNets(QPainter &painter, const QRect &viewport, bool order,
     {
         if (!::controller.getSimZ80().isNetOrphan(i))
         {
-            bool active;
+            bool active = false;
             switch (mode)
             {
                 case 0: // 0:Active

--- a/src/DialogSchematic.h
+++ b/src/DialogSchematic.h
@@ -3,6 +3,7 @@
 
 #include "AppTypes.h"
 #include "ClassLogic.h"
+#include "ClassNetlist.h"
 #include <QDialog>
 #include <QGraphicsScene>
 #include <QMenu>

--- a/src/WidgetGraphicsView.h
+++ b/src/WidgetGraphicsView.h
@@ -2,6 +2,7 @@
 #define WIDGETGRAPHICSVIEW_H
 
 #include "ClassLogic.h"
+#include "ClassNetlist.h"
 #include <QGraphicsPolygonItem>
 #include <QGraphicsView>
 


### PR DESCRIPTION
Fix incomplete type errors for generated files `moc_DialogSchematic.cpp` and `moc_WidgetGraphicsView.cpp`.

Fix initializer list order warning in `ClassLogic.cpp`.

Fix uninitialized variable warning in `ClassVisual.cpp`.

Fixes #10 .