### PR TITLE
Fix overridden member function declaration

### DIFF
--- a/src/DockCommand.h
+++ b/src/DockCommand.h
@@ -24,7 +24,7 @@ private slots:
     void returnPressed();
 
 private:
-    bool eventFilter(QObject *, QEvent *);
+    bool eventFilter(QObject *, QEvent *) override;
 
 protected:
     void dragEnterEvent(QDragEnterEvent *event) override;


### PR DESCRIPTION
I got one additional warning when using `clang` instead of `gcc`:

Compiling with clang 21.1.5 on Arch Linux produces this warning:
```
In file included from ../src/DockCommand.cpp:3:
../src/DockCommand.h:27:10: warning: 'eventFilter' overrides a member
      function but is not marked 'override' [-Winconsistent-missing-override]
   27 |     bool eventFilter(QObject *, QEvent *);
      |          ^
/usr/include/qt6/QtCore/qobject.h:117:18: note: overridden virtual function
      is here
  117 |     virtual bool eventFilter(QObject *watched, QEvent *event);
      |                  ^
```

Fix by adding `override` to `eventFilter` declaration.